### PR TITLE
C API level 0: core execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
 )
 
 # secp256k1
-add_library(secp256k1 third_party/secp256k1/src/secp256k1.c)
+add_library(secp256k1 STATIC third_party/secp256k1/src/secp256k1.c)
 if(MSVC)
     target_link_libraries(secp256k1 PRIVATE gmp)
     target_compile_definitions(secp256k1 PUBLIC USE_NUM_GMP USE_FIELD_INV_NUM USE_SCALAR_INV_NUM)

--- a/lib/silkpre/precompile.h
+++ b/lib/silkpre/precompile.h
@@ -17,6 +17,8 @@
 #ifndef SILKPRE_PRECOMPILE_H_
 #define SILKPRE_PRECOMPILE_H_
 
+#define EXPORT __attribute__((visibility("default")))
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -45,8 +47,8 @@ typedef struct SilkpreContract {
     SilkpreRunFunction run;
 } SilkpreContract;
 
-uint64_t silkpre_ecrec_gas(const uint8_t* input, size_t len, int evmc_revision);
-SilkpreOutput silkpre_ecrec_run(const uint8_t* input, size_t len);
+EXPORT uint64_t silkpre_ecrec_gas(const uint8_t* input, size_t len, int evmc_revision);
+EXPORT SilkpreOutput silkpre_ecrec_run(const uint8_t* input, size_t len);
 
 uint64_t silkpre_sha256_gas(const uint8_t* input, size_t len, int evmc_revision);
 SilkpreOutput silkpre_sha256_run(const uint8_t* input, size_t len);
@@ -78,7 +80,24 @@ SilkpreOutput silkpre_snarkv_run(const uint8_t* input, size_t len);
 uint64_t silkpre_blake2_f_gas(const uint8_t* input, size_t len, int evmc_revision);
 SilkpreOutput silkpre_blake2_f_run(const uint8_t* input, size_t len);
 
-extern const SilkpreContract kSilkpreContracts[SILKPRE_NUMBER_OF_ISTANBUL_CONTRACTS];
+EXPORT extern const SilkpreContract kSilkpreContracts[SILKPRE_NUMBER_OF_ISTANBUL_CONTRACTS];
+
+struct SilkpreResult {
+    int status_code;
+    size_t output_size;
+};
+
+EXPORT SilkpreResult ethprecompiled_ecrecover(const uint8_t* input, size_t input_size, uint8_t* output,
+                                              size_t output_size);
+EXPORT SilkpreResult ethprecompiled_sha256(const uint8_t* input, size_t input_size, uint8_t* output,
+                                           size_t output_size);
+EXPORT SilkpreResult ethprecompiled_ripemd160(const uint8_t* input, size_t input_size, uint8_t* output,
+                                              size_t output_size);
+EXPORT SilkpreResult ethprecompiled_expmod(const uint8_t* input, size_t input_size, uint8_t* output,
+                                           size_t output_size);
+EXPORT SilkpreResult ethprecompiled_ecmul(const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size);
+EXPORT SilkpreResult ethprecompiled_blake2bf(const uint8_t* input, size_t input_size, uint8_t* output,
+                                             size_t output_size);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This is proof-of-concept of C API level 0 for Ethereum precompiles.

The level 0 expose core execution functionality of a precompile using common function signature.
The function receives input and output byte buffers.
It returns a pair: error code and number of bytes written to the output buffer (output size).

The user of the API must compute the gas cost and the maximum output size on its own.