### PR TITLE
Disable aarch64 optimizations on Linux

### DIFF
--- a/lib/silkpre/sha256.c
+++ b/lib/silkpre/sha256.c
@@ -28,7 +28,7 @@
 #include <cpuid.h>
 #include <x86intrin.h>
 
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) && defined(__APPLE__)
 
 #include <arm_neon.h>
 
@@ -482,7 +482,7 @@ __attribute__((constructor)) static void select_sha256_implementation() {
     }
 }
 
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) && defined(__APPLE__)
 
 // The following function was adapted from https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-arm.c
 /* sha256-arm.c - ARMv8 SHA extensions using C intrinsics     */


### PR DESCRIPTION
To avoid this compilation error on aarch64 Linux:
```
/usr/local/lib/gcc/aarch64-unknown-linux-gnu/11.1.0/include/arm_neon.h:25273:1: error: inlining failed in call to ‘always_inline’ ‘vsha256hq_u32’: target specific option mismatch
25273 | vsha256hq_u32 (uint32x4_t __hash_abcd, uint32x4_t __hash_efgh, uint32x4_t __wk)
      | ^~~~~~~~~~~~~
/silkworm/third_party/silkpre/lib/silkpre/sha256.c:637:18: note: called from here
  637 |         STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```